### PR TITLE
feat(schema): add pipeline_blacklist column

### DIFF
--- a/hivemind_sqlite_database/__init__.py
+++ b/hivemind_sqlite_database/__init__.py
@@ -14,7 +14,7 @@ from dataclasses import dataclass
 _VALID_COLUMNS = frozenset({
     "client_id", "api_key", "name", "description", "is_admin",
     "last_seen", "intent_blacklist", "skill_blacklist", "message_blacklist",
-    "allowed_types", "crypto_key", "password",
+    "pipeline_blacklist", "allowed_types", "crypto_key", "password",
     "can_broadcast", "can_escalate", "can_propagate",
 })
 
@@ -81,6 +81,7 @@ class SQLiteDB(AbstractDB):
                     intent_blacklist TEXT,
                     skill_blacklist TEXT,
                     message_blacklist TEXT,
+                    pipeline_blacklist TEXT,
                     allowed_types TEXT,
                     crypto_key VARCHAR(16),
                     password TEXT,
@@ -89,6 +90,13 @@ class SQLiteDB(AbstractDB):
                     can_propagate BOOLEAN DEFAULT TRUE
                 )
             """)
+            # Migration: existing databases predating pipeline_blacklist.
+            # ALTER TABLE ADD COLUMN is idempotent only via try/except — sqlite
+            # has no IF NOT EXISTS for column adds.
+            try:
+                self.conn.execute("ALTER TABLE clients ADD COLUMN pipeline_blacklist TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already exists
 
     def add_item(self, client: Client) -> bool:
         """
@@ -106,15 +114,17 @@ class SQLiteDB(AbstractDB):
                     INSERT OR REPLACE INTO clients (
                         client_id, api_key, name, description, is_admin,
                         last_seen, intent_blacklist, skill_blacklist,
-                        message_blacklist, allowed_types, crypto_key, password,
+                        message_blacklist, pipeline_blacklist, allowed_types,
+                        crypto_key, password,
                         can_broadcast, can_escalate, can_propagate
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     client.client_id, client.api_key, client.name, client.description,
                     client.is_admin, client.last_seen,
                     json.dumps(client.intent_blacklist),
                     json.dumps(client.skill_blacklist),
                     json.dumps(client.message_blacklist),
+                    json.dumps(client.pipeline_blacklist),
                     json.dumps(client.allowed_types),
                     client.crypto_key, client.password,
                     client.can_broadcast, client.can_escalate, client.can_propagate
@@ -190,6 +200,7 @@ class SQLiteDB(AbstractDB):
             intent_blacklist=json.loads(row["intent_blacklist"] or "[]"),
             skill_blacklist=json.loads(row["skill_blacklist"] or "[]"),
             message_blacklist=json.loads(row["message_blacklist"] or "[]"),
+            pipeline_blacklist=json.loads(row["pipeline_blacklist"] or "[]"),
             allowed_types=json.loads(row["allowed_types"] or "[]"),
             crypto_key=row["crypto_key"],
             password=row["password"],

--- a/hivemind_sqlite_database/__init__.py
+++ b/hivemind_sqlite_database/__init__.py
@@ -91,12 +91,17 @@ class SQLiteDB(AbstractDB):
                 )
             """)
             # Migration: existing databases predating pipeline_blacklist.
-            # ALTER TABLE ADD COLUMN is idempotent only via try/except — sqlite
-            # has no IF NOT EXISTS for column adds.
-            try:
-                self.conn.execute("ALTER TABLE clients ADD COLUMN pipeline_blacklist TEXT")
-            except sqlite3.OperationalError:
-                pass  # column already exists
+            # sqlite has no IF NOT EXISTS for ADD COLUMN, so probe PRAGMA to
+            # avoid catching backend-specific OperationalError subclasses
+            # (sqlite3.OperationalError vs sqlcipher3.dbapi2.OperationalError).
+            existing_cols = {
+                row["name"]
+                for row in self.conn.execute("PRAGMA table_info(clients)").fetchall()
+            }
+            if "pipeline_blacklist" not in existing_cols:
+                self.conn.execute(
+                    "ALTER TABLE clients ADD COLUMN pipeline_blacklist TEXT"
+                )
 
     def add_item(self, client: Client) -> bool:
         """

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -389,5 +389,123 @@ class TestSQLiteDBMissingCipher(unittest.TestCase):
                 self.assertIn("sqlcipher3", str(ctx.exception))
 
 
+class TestSQLiteDBPipelineBlacklist(unittest.TestCase):
+    def test_schema_includes_pipeline_blacklist_column(self):
+        db = make_db()
+        cur = db.conn.execute("PRAGMA table_info(clients)")
+        cols = {row["name"] for row in cur.fetchall()}
+        self.assertIn("pipeline_blacklist", cols)
+
+    def test_pipeline_blacklist_is_a_valid_search_column(self):
+        from hivemind_sqlite_database import _VALID_COLUMNS
+        self.assertIn("pipeline_blacklist", _VALID_COLUMNS)
+
+    def test_roundtrip_with_values(self):
+        db = make_db()
+        c = make_client(
+            pipeline_blacklist=[
+                "ovos-fallback-pipeline-plugin-low",
+                "ovos-stop-pipeline-plugin-medium",
+            ]
+        )
+        self.assertTrue(db.add_item(c))
+        got = next(iter(db))
+        self.assertEqual(
+            got.pipeline_blacklist,
+            [
+                "ovos-fallback-pipeline-plugin-low",
+                "ovos-stop-pipeline-plugin-medium",
+            ],
+        )
+
+    def test_roundtrip_default_empty_list(self):
+        db = make_db()
+        self.assertTrue(db.add_item(make_client()))
+        got = next(iter(db))
+        self.assertEqual(got.pipeline_blacklist, [])
+
+    def test_legacy_schema_is_migrated_in_place(self):
+        """An existing DB predating pipeline_blacklist gets the column added on init."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            path = f.name
+        try:
+            # Hand-craft the pre-pipeline_blacklist schema and seed a row.
+            con = sqlite3.connect(path)
+            con.execute(
+                """
+                CREATE TABLE clients (
+                    client_id INTEGER PRIMARY KEY,
+                    api_key VARCHAR(255) NOT NULL,
+                    name VARCHAR(255),
+                    description VARCHAR(255),
+                    is_admin BOOLEAN DEFAULT FALSE,
+                    last_seen REAL DEFAULT -1,
+                    intent_blacklist TEXT,
+                    skill_blacklist TEXT,
+                    message_blacklist TEXT,
+                    allowed_types TEXT,
+                    crypto_key VARCHAR(16),
+                    password TEXT,
+                    can_broadcast BOOLEAN DEFAULT TRUE,
+                    can_escalate BOOLEAN DEFAULT TRUE,
+                    can_propagate BOOLEAN DEFAULT TRUE
+                )
+                """
+            )
+            con.execute(
+                "INSERT INTO clients (client_id, api_key, name, intent_blacklist,"
+                " skill_blacklist, message_blacklist, allowed_types)"
+                " VALUES (1, 'k', 'legacy', '[]', '[]', '[]', '[]')"
+            )
+            con.commit()
+            con.close()
+
+            # Re-open through SQLiteDB, which should ALTER TABLE in-place.
+            db = object.__new__(SQLiteDB)
+            db.name = "clients"
+            db.subfolder = "hivemind-core"
+            db.conn = sqlite3.connect(path, check_same_thread=False)
+            db.conn.row_factory = sqlite3.Row
+            db.conn.execute("PRAGMA journal_mode=WAL")
+            db._write_lock = threading.Lock()
+            db._initialize_database()
+
+            cur = db.conn.execute("PRAGMA table_info(clients)")
+            cols = {row["name"] for row in cur.fetchall()}
+            self.assertIn("pipeline_blacklist", cols)
+
+            # Existing rows back-fill to [] and new rows persist correctly.
+            legacy = next(iter(db))
+            self.assertEqual(legacy.pipeline_blacklist, [])
+
+            self.assertTrue(db.add_item(make_client(client_id=2, api_key="k2",
+                                                   pipeline_blacklist=["x"])))
+            got = sorted(list(db), key=lambda c: c.client_id)
+            self.assertEqual(got[1].pipeline_blacklist, ["x"])
+        finally:
+            os.unlink(path)
+
+    def test_repeated_init_does_not_raise(self):
+        """ALTER TABLE is guarded; init on an already-migrated DB is a no-op."""
+        with tempfile.NamedTemporaryFile(suffix=".db", delete=False) as f:
+            path = f.name
+        try:
+            def _open() -> SQLiteDB:
+                db = object.__new__(SQLiteDB)
+                db.name = "clients"
+                db.subfolder = "hivemind-core"
+                db.conn = sqlite3.connect(path, check_same_thread=False)
+                db.conn.row_factory = sqlite3.Row
+                db.conn.execute("PRAGMA journal_mode=WAL")
+                db._write_lock = threading.Lock()
+                db._initialize_database()
+                return db
+
+            _open()  # first run creates the table
+            _open()  # second run must not raise on the ALTER
+        finally:
+            os.unlink(path)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Adds a per-client `pipeline_blacklist` column to the SQLite schema, mirroring `skill_blacklist` / `intent_blacklist` / `message_blacklist`.

## What

- `clients.pipeline_blacklist TEXT` (JSON list of pipeline plugin IDs).
- `_VALID_COLUMNS`, `INSERT OR REPLACE`, and `_row_to_client` updated.
- Lazy migration: `ALTER TABLE ADD COLUMN pipeline_blacklist TEXT` guarded by try/except so re-init on an existing DB is a no-op (sqlite has no `IF NOT EXISTS` for column adds).

## Verified locally

- New DB → roundtrip with non-empty list works.
- Pre-existing DB without the column → migration runs once, old rows back-fill to `[]`, new clients with the field persist correctly.

## Dependency

Needs `Client.pipeline_blacklist` from hivemind-plugin-manager (PR JarbasHiveMind/hivemind-plugin-manager#18). Land that first; the dep range here (`>=0.1.0,<1.0.0`) is already permissive so no version bump required, just ordering.

## Follow-ups

- hivemind-redis-database PR (also adds `pipeline_blacklist` to its attr loop).
- HiveMind-core PR (enforces the filter in `_update_blacklist`, exposes CLI commands).