### PR TITLE
Preserve client metadata

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -13,3 +13,4 @@ jobs:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: ''
       test_path: 'tests'
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -15,3 +15,4 @@ jobs:
       test_path: 'tests/'
       install_extras: ''
       min_coverage: 0
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -9,3 +9,5 @@ jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,3 +12,4 @@ jobs:
     with:
       ruff: true
       pre_commit: false   # set true if .pre-commit-config.yaml exists
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -9,3 +9,5 @@ jobs:
   pip_audit:
     uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
     secrets: inherit
+    with:
+      pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   release_preview:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
     secrets: inherit
     with:

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -7,6 +7,7 @@ on:
 
 jobs:
   repo_health:
+    if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
     secrets: inherit
     with:

--- a/hivemind_sqlite_database/__init__.py
+++ b/hivemind_sqlite_database/__init__.py
@@ -9,13 +9,16 @@ from ovos_utils.xdg_utils import xdg_data_home
 
 from hivemind_plugin_manager.database import Client, AbstractDB
 
-from dataclasses import dataclass
+from dataclasses import dataclass, fields
+
+
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
 
 _VALID_COLUMNS = frozenset({
     "client_id", "api_key", "name", "description", "is_admin",
     "last_seen", "intent_blacklist", "skill_blacklist", "message_blacklist",
     "allowed_types", "crypto_key", "password",
-    "can_broadcast", "can_escalate", "can_propagate",
+    "can_broadcast", "can_escalate", "can_propagate", "metadata",
 })
 
 
@@ -86,9 +89,16 @@ class SQLiteDB(AbstractDB):
                     password TEXT,
                     can_broadcast BOOLEAN DEFAULT TRUE,
                     can_escalate BOOLEAN DEFAULT TRUE,
-                    can_propagate BOOLEAN DEFAULT TRUE
+                    can_propagate BOOLEAN DEFAULT TRUE,
+                    metadata TEXT
                 )
             """)
+            columns = {
+                row["name"]
+                for row in self.conn.execute("PRAGMA table_info(clients)").fetchall()
+            }
+            if "metadata" not in columns:
+                self.conn.execute("ALTER TABLE clients ADD COLUMN metadata TEXT")
 
     def add_item(self, client: Client) -> bool:
         """
@@ -101,14 +111,15 @@ class SQLiteDB(AbstractDB):
             True if the addition was successful, False otherwise.
         """
         try:
+            metadata_json = self._metadata_to_json(getattr(client, "metadata", {}) or {})
             with self._write_lock, self.conn:
                 self.conn.execute("""
                     INSERT OR REPLACE INTO clients (
                         client_id, api_key, name, description, is_admin,
                         last_seen, intent_blacklist, skill_blacklist,
                         message_blacklist, allowed_types, crypto_key, password,
-                        can_broadcast, can_escalate, can_propagate
-                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                        can_broadcast, can_escalate, can_propagate, metadata
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
                 """, (
                     client.client_id, client.api_key, client.name, client.description,
                     client.is_admin, client.last_seen,
@@ -117,7 +128,8 @@ class SQLiteDB(AbstractDB):
                     json.dumps(client.message_blacklist),
                     json.dumps(client.allowed_types),
                     client.crypto_key, client.password,
-                    client.can_broadcast, client.can_escalate, client.can_propagate
+                    client.can_broadcast, client.can_escalate, client.can_propagate,
+                    metadata_json,
                 ))
             return True
         except sqlite3.Error as e:
@@ -180,20 +192,42 @@ class SQLiteDB(AbstractDB):
     @staticmethod
     def _row_to_client(row: sqlite3.Row) -> Client:
         """Convert a database row to a Client instance."""
-        return Client(
-            client_id=int(row["client_id"]),
-            api_key=row["api_key"],
-            name=row["name"],
-            description=row["description"],
-            is_admin=bool(row["is_admin"]),
-            last_seen=row["last_seen"],
-            intent_blacklist=json.loads(row["intent_blacklist"] or "[]"),
-            skill_blacklist=json.loads(row["skill_blacklist"] or "[]"),
-            message_blacklist=json.loads(row["message_blacklist"] or "[]"),
-            allowed_types=json.loads(row["allowed_types"] or "[]"),
-            crypto_key=row["crypto_key"],
-            password=row["password"],
-            can_broadcast=bool(row["can_broadcast"]),
-            can_escalate=bool(row["can_escalate"]),
-            can_propagate=bool(row["can_propagate"])
-        )
+        kwargs = {
+            "client_id": int(row["client_id"]),
+            "api_key": row["api_key"],
+            "name": row["name"],
+            "description": row["description"],
+            "is_admin": bool(row["is_admin"]),
+            "last_seen": row["last_seen"],
+            "intent_blacklist": json.loads(row["intent_blacklist"] or "[]"),
+            "skill_blacklist": json.loads(row["skill_blacklist"] or "[]"),
+            "message_blacklist": json.loads(row["message_blacklist"] or "[]"),
+            "allowed_types": json.loads(row["allowed_types"] or "[]"),
+            "crypto_key": row["crypto_key"],
+            "password": row["password"],
+            "can_broadcast": bool(row["can_broadcast"]),
+            "can_escalate": bool(row["can_escalate"]),
+            "can_propagate": bool(row["can_propagate"]),
+        }
+        if CLIENT_SUPPORTS_METADATA:
+            kwargs["metadata"] = SQLiteDB._metadata_from_row(row)
+        return Client(**kwargs)
+
+    @staticmethod
+    def _metadata_to_json(metadata: object) -> str:
+        if not isinstance(metadata, dict):
+            return "{}"
+        try:
+            return json.dumps(metadata, default=str)
+        except (TypeError, ValueError):
+            return "{}"
+
+    @staticmethod
+    def _metadata_from_row(row: sqlite3.Row) -> dict:
+        if "metadata" not in row.keys() or not row["metadata"]:
+            return {}
+        try:
+            metadata = json.loads(row["metadata"])
+        except (TypeError, ValueError):
+            return {}
+        return metadata if isinstance(metadata, dict) else {}

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -7,9 +7,14 @@ import tempfile
 import threading
 import os
 import unittest
+from dataclasses import fields
 
 from hivemind_plugin_manager.database import Client
 from hivemind_sqlite_database import SQLiteDB
+
+
+CLIENT_SUPPORTS_METADATA = any(field.name == "metadata" for field in fields(Client))
+METADATA_SUPPORT_REQUIRED = "Client.metadata requires hivemind-plugin-manager metadata support"
 
 
 def make_db() -> SQLiteDB:
@@ -26,7 +31,11 @@ def make_db() -> SQLiteDB:
 
 
 def make_client(client_id: int = 1, api_key: str = "key-abc", **kwargs) -> Client:
-    return Client(client_id=client_id, api_key=api_key, **kwargs)
+    metadata = kwargs.pop("metadata", None)
+    client = Client(client_id=client_id, api_key=api_key, **kwargs)
+    if metadata is not None:
+        client.metadata = metadata
+    return client
 
 
 class TestSQLiteDBWAL(unittest.TestCase):
@@ -236,9 +245,100 @@ class TestSQLiteDBRoundTrip(unittest.TestCase):
         self.assertIs(type(results[0].can_broadcast), bool)
         self.assertFalse(results[0].can_broadcast)
 
+    def test_metadata_survives_round_trip(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        db = make_db()
+        db.add_item(
+            make_client(
+                1,
+                "k1",
+                metadata={"owner_id": "owner-123"},
+            )
+        )
+
+        results = db.search_by_value("api_key", "k1")
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].metadata, {"owner_id": "owner-123"})
+
+    def test_metadata_can_be_searched(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        db = make_db()
+        db.add_item(
+            make_client(
+                1,
+                "k1",
+                metadata={"owner_id": "owner-123"},
+            )
+        )
+
+        results = db.search_by_value("metadata", '{"owner_id": "owner-123"}')
+
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0].api_key, "k1")
+
+    def test_initialize_database_migrates_legacy_clients_table(self):
+        db = object.__new__(SQLiteDB)
+        db.name = "clients"
+        db.subfolder = "hivemind-core"
+        db.conn = sqlite3.connect(":memory:", check_same_thread=False)
+        db.conn.row_factory = sqlite3.Row
+        db._write_lock = threading.Lock()
+        with db.conn:
+            db.conn.execute("""
+                CREATE TABLE clients (
+                    client_id INTEGER PRIMARY KEY,
+                    api_key VARCHAR(255) NOT NULL,
+                    name VARCHAR(255),
+                    description VARCHAR(255),
+                    is_admin BOOLEAN DEFAULT FALSE,
+                    last_seen REAL DEFAULT -1,
+                    intent_blacklist TEXT,
+                    skill_blacklist TEXT,
+                    message_blacklist TEXT,
+                    allowed_types TEXT,
+                    crypto_key VARCHAR(16),
+                    password TEXT,
+                    can_broadcast BOOLEAN DEFAULT TRUE,
+                    can_escalate BOOLEAN DEFAULT TRUE,
+                    can_propagate BOOLEAN DEFAULT TRUE
+                )
+            """)
+            db.conn.execute("INSERT INTO clients (client_id, api_key) VALUES (1, 'k1')")
+
+        db._initialize_database()
+
+        columns = {
+            row["name"]
+            for row in db.conn.execute("PRAGMA table_info(clients)").fetchall()
+        }
+        self.assertIn("metadata", columns)
+        client = db.search_by_value("api_key", "k1")[0]
+        if CLIENT_SUPPORTS_METADATA:
+            self.assertEqual(client.metadata, {})
+
+    def test_metadata_survives_iteration(self):
+        if not CLIENT_SUPPORTS_METADATA:
+            self.skipTest(METADATA_SUPPORT_REQUIRED)
+        db = make_db()
+        db.add_item(
+            make_client(
+                1,
+                "k1",
+                metadata={"owner_id": "owner-123"},
+            )
+        )
+
+        clients = list(db)
+
+        self.assertEqual(len(clients), 1)
+        self.assertEqual(clients[0].metadata, {"owner_id": "owner-123"})
+
     def test_full_client_fields_preserved(self):
         db = make_db()
-        c = Client(
+        c = make_client(
             client_id=42,
             api_key="full-key",
             name="test-client",
@@ -254,6 +354,7 @@ class TestSQLiteDBRoundTrip(unittest.TestCase):
             can_broadcast=True,
             can_escalate=False,
             can_propagate=True,
+            metadata={"owner_id": "owner-123"},
         )
         db.add_item(c)
         results = db.search_by_value("api_key", "full-key")
@@ -267,6 +368,8 @@ class TestSQLiteDBRoundTrip(unittest.TestCase):
         self.assertEqual(r.crypto_key, "1234567890123456")
         self.assertEqual(r.password, "secret")
         self.assertFalse(r.can_escalate)
+        if CLIENT_SUPPORTS_METADATA:
+            self.assertEqual(r.metadata, {"owner_id": "owner-123"})
 
 
 class TestSQLiteDBCommit(unittest.TestCase):


### PR DESCRIPTION
Stores `Client.metadata` in SQLite and migrates older tables by adding the column when missing.

Needs client metadata support in JarbasHiveMind/hivemind-plugin-manager#21.