### PR TITLE
ci: pass PYPI_TOKEN explicitly, drop secrets:inherit elsewhere

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   build:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
-    secrets: inherit
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
       install_extras: ''

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   coverage:
     uses: OpenVoiceOS/gh-automations/.github/workflows/coverage.yml@dev
-    secrets: inherit
     with:
       python_version: '3.11'
       coverage_source: 'hivemind_sqlite_database'

--- a/.github/workflows/license_check.yml
+++ b/.github/workflows/license_check.yml
@@ -8,6 +8,5 @@ on:
 jobs:
   license_check:
     uses: OpenVoiceOS/gh-automations/.github/workflows/license-check.yml@dev
-    secrets: inherit
     with:
       pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -8,7 +8,6 @@ on:
 jobs:
   lint:
     uses: OpenVoiceOS/gh-automations/.github/workflows/lint.yml@dev
-    secrets: inherit
     with:
       ruff: true
       pre_commit: false   # set true if .pre-commit-config.yaml exists

--- a/.github/workflows/pip_audit.yml
+++ b/.github/workflows/pip_audit.yml
@@ -8,6 +8,5 @@ on:
 jobs:
   pip_audit:
     uses: OpenVoiceOS/gh-automations/.github/workflows/pip-audit.yml@dev
-    secrets: inherit
     with:
       pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   publish_stable:
     uses: OpenVoiceOS/gh-automations/.github/workflows/publish-stable.yml@dev
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     with:
       branch: 'master'
       version_file: 'hivemind_sqlite_database/version.py'

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -9,7 +9,6 @@ jobs:
   release_preview:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/release-preview.yml@dev
-    secrets: inherit
     with:
       package_name: 'hivemind_sqlite_database'
       version_file: 'hivemind_sqlite_database/version.py'

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types: [closed]
     branches: [dev]
+  workflow_dispatch:
 
 jobs:
   publish_alpha:

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -8,7 +8,8 @@ on:
 jobs:
   publish_alpha:
     uses: OpenVoiceOS/gh-automations/.github/workflows/publish-alpha.yml@dev
-    secrets: inherit
+    secrets:
+      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
     with:
       branch: 'dev'
       base_branch: 'master'

--- a/.github/workflows/repo-health.yml
+++ b/.github/workflows/repo-health.yml
@@ -9,6 +9,5 @@ jobs:
   repo_health:
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     uses: OpenVoiceOS/gh-automations/.github/workflows/repo-health.yml@dev
-    secrets: inherit
     with:
       version_file: 'hivemind_sqlite_database/version.py'


### PR DESCRIPTION
`secrets: inherit` fails when calling `publish-stable.yml`/`publish-alpha.yml` from gh-automations. Pass `PYPI_TOKEN` explicitly. For other workflows that don't declare any secrets upstream, drop the `secrets:` line entirely — there's nothing to pass through.

Same fix being applied across hivemind-redis-database and TigreGotico/json_database.