### PR TITLE
ci: dedupe tests.yml — drop test-plain, rename to cipher-tests.yml

### DIFF
--- a/.github/workflows/cipher-tests.yml
+++ b/.github/workflows/cipher-tests.yml
@@ -1,24 +1,16 @@
-name: Tests
+name: Cipher Tests
+
+# Dedicated workflow for the [cipher] extra (sqlcipher3 + libsqlcipher-dev).
+# The shared build-tests.yml covers the unencrypted path on Python 3.10-3.14;
+# this one adds a single Python 3.11 run with sqlcipher installed so the
+# encrypted backend is exercised on every PR.
 
 on:
-  push:
-    branches: ["**"]
   pull_request:
-    branches: ["**"]
+    branches: [dev, master, main]
+  workflow_dispatch:
 
 jobs:
-  test-plain:
-    name: "SQLite (no encryption)"
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: pip install -e ".[dev]" || pip install -e .
-      - run: pip install pytest
-      - run: pytest tests/test_sqlitedb.py -q -p no:ovoscope
-
   test-cipher:
     name: "SQLite + SQLCipher"
     runs-on: ubuntu-latest


### PR DESCRIPTION
Drops the redundant `test-plain` job (the shared `build-tests.yml` already runs the unencrypted path across Python 3.10-3.14) and renames the remaining file to `cipher-tests.yml` so its purpose is obvious. The cipher job stays — it's the only place that installs `libsqlcipher-dev` + the `[cipher]` extra and exercises the SQLCipher path. Also narrows the triggers from catch-all push/PR to the standard `pull_request: [dev, master, main]` + `workflow_dispatch:`.