### PR TITLE
test: hivescope e2e + CI

### DIFF
--- a/.github/workflows/build-tests.yml
+++ b/.github/workflows/build-tests.yml
@@ -10,7 +10,6 @@ jobs:
     uses: OpenVoiceOS/gh-automations/.github/workflows/build-tests.yml@dev
     with:
       python_versions: '["3.10", "3.11", "3.12", "3.13", "3.14"]'
-      install_extras: ''
-      pre_install_pip: '"hivemind-plugin-manager==0.6.0a1"'
+      install_extras: 'test'
       test_path: 'tests'
       pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -12,7 +12,7 @@ jobs:
       python_version: '3.11'
       coverage_source: 'hivemind_sqlite_database'
       pre_install_pip: '"hivemind-plugin-manager==0.6.0a1"'
-      test_path: 'tests/'
+      test_path: 'tests/ --ignore=tests/e2e'
       install_extras: ''
       min_coverage: 0
       pr_comment: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,11 @@ dependencies = [
 
 [project.optional-dependencies]
 cipher = ["sqlcipher3"]
+test = [
+    "pytest",
+    "hivescope>=0.5.2a1",
+    "hivemind-plugin-manager>=0.7.1a1",
+]
 
 [project.urls]
 Homepage = "https://github.com/JarbasHiveMind/hivemind-sqlite-database"

--- a/tests/e2e/test_hivescope_client_db_e2e.py
+++ b/tests/e2e/test_hivescope_client_db_e2e.py
@@ -1,0 +1,149 @@
+"""End-to-end: a real SQLiteDB backend used as the client-credential
+database of a live hivescope MasterNode.
+
+Exercises the full client-database seam through a real HiveMind topology:
+
+    satellite admission --> SQLiteDB.add_client (row in the .db file)
+    handshake / message routing --> SQLiteDB api_key lookup
+    master restart (new connection to the same .db file)
+        --> credentials persist and still admit the satellite
+"""
+import tempfile
+import time
+from unittest import mock
+
+import pytest
+
+from hivemind_bus_client.message import HiveMessage, HiveMessageType
+from ovos_bus_client.message import Message
+from hivemind_core.database import ClientDatabase
+from hivescope.topology import TopologyBuilder
+from hivescope.assertions import assert_handshake_complete, assert_bus_message_routed
+
+from hivemind_sqlite_database import SQLiteDB
+
+_SQLITE_PLUGIN = "hivemind-sqlite-db-plugin"
+
+
+class _HivescopeDBAdapter:
+    """Bridges hivescope's ``register_satellite`` (which passes
+    ``can_escalate``/``can_propagate``/``can_broadcast`` to ``add_client``)
+    to the real ``ClientDatabase`` whose ``add_client`` does not take them.
+    Everything else delegates straight to the backing ClientDatabase, so the
+    master resolves real clients from the real SQLite backend.
+    """
+
+    def __init__(self, cdb):
+        object.__setattr__(self, "_cdb", cdb)
+
+    def add_client(self, name, key, password=None, admin=False,
+                   crypto_key=None, allowed_types=None, metadata=None,
+                   intent_blacklist=None, skill_blacklist=None,
+                   message_blacklist=None, can_escalate=True,
+                   can_propagate=True, can_broadcast=True):
+        return self._cdb.add_client(
+            name=name, key=key, admin=admin, allowed_types=allowed_types,
+            crypto_key=crypto_key, password=password, metadata=metadata,
+            intent_blacklist=intent_blacklist, skill_blacklist=skill_blacklist,
+            message_blacklist=message_blacklist,
+        )
+
+    def __getattr__(self, item):
+        return getattr(object.__getattribute__(self, "_cdb"), item)
+
+    def __iter__(self):
+        return iter(self._cdb)
+
+    def __len__(self):
+        return len(self._cdb)
+
+    def __enter__(self):
+        return self._cdb.__enter__()
+
+    def __exit__(self, *a):
+        return self._cdb.__exit__(*a)
+
+
+@pytest.fixture()
+def data_home():
+    """Point xdg_data_home at a temp dir so every SQLiteDB the test opens
+    shares one on-disk database file, exactly like a master restarting
+    against its data directory."""
+    with tempfile.TemporaryDirectory() as tmp:
+        with mock.patch("hivemind_sqlite_database.xdg_data_home",
+                        return_value=tmp):
+            yield tmp
+
+
+def _open_client_db() -> ClientDatabase:
+    cdb = ClientDatabase(config={
+        "module": _SQLITE_PLUGIN,
+        _SQLITE_PLUGIN: {"name": "clients", "subfolder": "hivemind-core"},
+    })
+    # Pin this repo's SQLiteDB explicitly so an editable install always
+    # exercises the local code even if another distribution claims the
+    # same entry-point name.
+    cdb.db = SQLiteDB(name="clients", subfolder="hivemind-core")
+    return cdb
+
+
+def test_client_db_backend_registration_lookup_and_persistence(data_home):
+    cdb = _open_client_db()
+
+    b = TopologyBuilder()
+    m = b.add_master("M0", db=_HivescopeDBAdapter(cdb), require_crypto=False)
+    s = b.add_satellite(
+        "S0", upstream=m, is_admin=False,
+        allowed_types=["recognizer_loop:utterance"],
+    )
+    b.start_all()
+    try:
+        assert_handshake_complete(m, s)
+        key = s.identity.access_key
+
+        # --- registration: the admission wrote a real row into SQLite ---
+        client = cdb.get_client_by_api_key(key)
+        assert client is not None, "admitted satellite not found in SQLiteDB"
+        assert client.api_key == key
+        assert "recognizer_loop:utterance" in (client.allowed_types or [])
+
+        # --- lookup: the connected client is resolved from the backend ---
+        seen = []
+        m.agent_protocol.bus.on("recognizer_loop:utterance", seen.append)
+        s.send(HiveMessage(
+            HiveMessageType.BUS,
+            payload=Message("recognizer_loop:utterance",
+                            {"utterances": ["hello hive"]}),
+        ))
+        deadline = time.monotonic() + 2.0
+        while time.monotonic() < deadline and not seen:
+            time.sleep(0.02)
+        assert seen, "utterance never reached the agent bus"
+        assert_bus_message_routed(m, count=1)
+    finally:
+        b.stop_all()
+
+    # --- persistence: a fresh connection to the same .db file (the master
+    # "reconnecting" after a restart) still resolves the client ---
+    cdb2 = _open_client_db()
+    persisted = cdb2.get_client_by_api_key(key)
+    assert persisted is not None, "client credentials lost across reconnect"
+    assert persisted.api_key == key
+    assert persisted.name == client.name
+    assert persisted.client_id == client.client_id
+    assert "recognizer_loop:utterance" in (persisted.allowed_types or [])
+
+    # And a restarted master wired to the reconnected backend admits a
+    # satellite while the pre-restart client is still on record.
+    b2 = TopologyBuilder()
+    m2 = b2.add_master("M1", db=_HivescopeDBAdapter(cdb2), require_crypto=False)
+    s2 = b2.add_satellite("S1", upstream=m2, is_admin=False)
+    b2.start_all()
+    try:
+        assert_handshake_complete(m2, s2)
+        # both the pre-restart and post-restart clients live in the same DB
+        assert cdb2.get_client_by_api_key(key) is not None
+        assert cdb2.get_client_by_api_key(s2.identity.access_key) is not None
+        assert cdb2.total_clients() >= 2
+    finally:
+        b2.stop_all()


### PR DESCRIPTION
## What

- New `tests/e2e/test_hivescope_client_db_e2e.py`: stands up a hivescope `MasterNode` whose client database is a real `ClientDatabase` backed by this repo's `SQLiteDB` (xdg data home pointed at a temp dir). It admits a `SatelliteNode`, asserts the credentials were persisted as a real SQLite row (`get_client_by_api_key`), routes a BUS message through the topology (client resolved from the backend), then reopens a brand-new `SQLiteDB` connection against the same `.db` file and verifies the client survives a simulated master restart/reconnect and a restarted master keeps admitting satellites from the same store.
- `pyproject.toml`: new `test` extra — `pytest`, `hivescope>=0.5.2a1`, `hivemind-plugin-manager>=0.7.1a1` (floor moves out of CI into the extra where dependency versions belong).
- `build-tests.yml`: `install_extras: 'test'` and drop the `pre_install_pip` plugin-manager pin, so the standard `pip install .[test]` resolves the whole hivescope stack and `tests/` (incl. e2e) runs on every matrix entry.

## Verification

Fresh venv, `pip install -e .[test]`, `pytest tests/`: 62 passed, 3 skipped (policy-migration e2e still gated on the policy stack). Ruff clean. No external service needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)