### PR TITLE
fix: advance last_seen atomically

### DIFF
--- a/hivemind_sqlite_database/__init__.py
+++ b/hivemind_sqlite_database/__init__.py
@@ -215,6 +215,26 @@ class SQLiteDB(AbstractDB):
             LOG.error(f"Failed to add client to SQLite: {e}")
             return False
 
+    def update_last_seen(self, api_key: str, seen_at: float) -> bool:
+        """Atomically advance ``last_seen`` for the matching API key."""
+        try:
+            with self._write_lock, self.conn:
+                cursor = self.conn.execute(
+                    """
+                    UPDATE clients
+                    SET last_seen = CASE
+                        WHEN last_seen IS NULL OR last_seen < ? THEN ?
+                        ELSE last_seen
+                    END
+                    WHERE api_key = ?
+                    """,
+                    (seen_at, seen_at, api_key),
+                )
+            return cursor.rowcount > 0
+        except sqlite3.Error as e:
+            LOG.error(f"Failed to update last_seen in SQLite: {e}")
+            return False
+
     def search_by_value(self, key: str, val: Union[str, bool, int, float]) -> List[Client]:
         """
         Search for clients by a specific key-value pair in the SQLite database.

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -189,6 +189,22 @@ class TestSQLiteDBSearchByValue(unittest.TestCase):
         self.assertEqual(results, [])
 
 
+class TestSQLiteDBLastSeen(unittest.TestCase):
+    def test_update_last_seen_never_moves_timestamp_backward(self):
+        db = make_db()
+        db.add_item(make_client(1, "key", last_seen=200.0))
+
+        self.assertTrue(db.update_last_seen("key", 100.0))
+        self.assertEqual(db.search_by_value("api_key", "key")[0].last_seen, 200.0)
+
+        self.assertTrue(db.update_last_seen("key", 300.0))
+        self.assertEqual(db.search_by_value("api_key", "key")[0].last_seen, 300.0)
+
+    def test_update_last_seen_returns_false_for_missing_key(self):
+        db = make_db()
+        self.assertFalse(db.update_last_seen("missing", 100.0))
+
+
 class TestSQLiteDBIter(unittest.TestCase):
     def test_iter_yields_all_rows(self):
         db = make_db()


### PR DESCRIPTION
Adds a single-statement SQLite conditional update so delayed asynchronous writers cannot move a client activity timestamp backward.\n\nValidation: 38 passed, 3 skipped; ruff and diff checks passed.\n\nPairs with JarbasHiveMind/HiveMind-core#150.