### PR TITLE
ci: release safely after fork merges

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,10 +1,14 @@
 name: Release Alpha and Propose Stable
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
     branches: [dev]
   workflow_dispatch:
+
+permissions:
+  contents: write
+  pull-requests: write
 
 jobs:
   publish_alpha:
@@ -20,5 +24,4 @@ jobs:
       changelog_max_issues: 100
       publish_pypi: true
       propose_release: true
-      notify_matrix: true
-      matrix_channel: '!jImYhOcJWVpvCRsDjc:matrix.org'
+      notify_matrix: false


### PR DESCRIPTION
## Summary
- use `pull_request_target` for the closed/merged release trigger so the base repository token can bump `dev`
- grant the reusable release workflow its required write permissions
- disable the failing optional Matrix notification

The target workflow reads and publishes the trusted `dev` branch; it never checks out or executes the fork head.

## Validation
- parsed every workflow as YAML
- `git diff --check`