### PR TITLE
Revert unauthorized automated merges (#44, #45)

### DIFF
--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -1,14 +1,10 @@
 name: Release Alpha and Propose Stable
 
 on:
-  pull_request_target:
+  pull_request:
     types: [closed]
     branches: [dev]
   workflow_dispatch:
-
-permissions:
-  contents: write
-  pull-requests: write
 
 jobs:
   publish_alpha:
@@ -24,4 +20,5 @@ jobs:
       changelog_max_issues: 100
       publish_pypi: true
       propose_release: true
-      notify_matrix: false
+      notify_matrix: true
+      matrix_channel: '!jImYhOcJWVpvCRsDjc:matrix.org'

--- a/hivemind_sqlite_database/__init__.py
+++ b/hivemind_sqlite_database/__init__.py
@@ -215,26 +215,6 @@ class SQLiteDB(AbstractDB):
             LOG.error(f"Failed to add client to SQLite: {e}")
             return False
 
-    def update_last_seen(self, api_key: str, seen_at: float) -> bool:
-        """Atomically advance ``last_seen`` for the matching API key."""
-        try:
-            with self._write_lock, self.conn:
-                cursor = self.conn.execute(
-                    """
-                    UPDATE clients
-                    SET last_seen = CASE
-                        WHEN last_seen IS NULL OR last_seen < ? THEN ?
-                        ELSE last_seen
-                    END
-                    WHERE api_key = ?
-                    """,
-                    (seen_at, seen_at, api_key),
-                )
-            return cursor.rowcount > 0
-        except sqlite3.Error as e:
-            LOG.error(f"Failed to update last_seen in SQLite: {e}")
-            return False
-
     def search_by_value(self, key: str, val: Union[str, bool, int, float]) -> List[Client]:
         """
         Search for clients by a specific key-value pair in the SQLite database.

--- a/tests/test_sqlitedb.py
+++ b/tests/test_sqlitedb.py
@@ -189,22 +189,6 @@ class TestSQLiteDBSearchByValue(unittest.TestCase):
         self.assertEqual(results, [])
 
 
-class TestSQLiteDBLastSeen(unittest.TestCase):
-    def test_update_last_seen_never_moves_timestamp_backward(self):
-        db = make_db()
-        db.add_item(make_client(1, "key", last_seen=200.0))
-
-        self.assertTrue(db.update_last_seen("key", 100.0))
-        self.assertEqual(db.search_by_value("api_key", "key")[0].last_seen, 200.0)
-
-        self.assertTrue(db.update_last_seen("key", 300.0))
-        self.assertEqual(db.search_by_value("api_key", "key")[0].last_seen, 300.0)
-
-    def test_update_last_seen_returns_false_for_missing_key(self):
-        db = make_db()
-        self.assertFalse(db.update_last_seen("missing", 100.0))
-
-
 class TestSQLiteDBIter(unittest.TestCase):
     def test_iter_yields_all_rows(self):
         db = make_db()


### PR DESCRIPTION
Reverts two PRs merged to `dev` by an automated coding agent that should not have had merge access.

- **#45** (`ci: release safely after fork merges`) switched the release workflow to `pull_request_target` (trusted token + secrets on fork-PR events) and added `contents: write`/`pull-requests: write`; it then auto-published `0.4.0a5` to PyPI without review. Reverted → trigger back to `pull_request`.
- **#44** (`advance last_seen atomically`) reverted as an unauthorized functional change.

Tests green on the reverted tree (62 passed). Published PyPI alpha left in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)