### PR TITLE
docs: rewrite README in Simplified Technical English

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Implements the [`hivemind-plugin-manager`](https://github.com/JarbasHiveMind/hiv
 encryption is enabled). Client records (API keys, crypto keys, access-control lists) are stored in
 a local `.db` file with WAL journal mode for safe multi-reader, single-writer access.
 
-**This is the default database backend for fresh hivemind-core installations.**
+This is the default database backend for fresh hivemind-core installations.
 
 ## Where it fits
 
@@ -99,13 +99,13 @@ typically `~/.local/share/hivemind-core/clients.db`.
 ## Schema migration
 
 On first open after an upgrade, `SQLiteDB` runs an automatic schema migration.
-Version tracking uses SQLite's built-in `PRAGMA user_version` — no sibling files.
+Version tracking uses SQLite's built-in `PRAGMA user_version`. There are no sibling files.
 
 The v1→v2 migration folds legacy `intent_blacklist` / `skill_blacklist` column
 data into each row's `metadata` JSON field and NULLs the legacy columns.
 `message_blacklist` is purged outright.
 
-The migration is idempotent, crash-safe, and transactional — the row rewrites
+The migration is idempotent and crash-safe. The row rewrites
 and the `user_version` bump happen in one transaction.
 
 To migrate an existing installation to this backend, use hivemind-core's built-in
@@ -117,6 +117,6 @@ hivemind-core migrate-db
 
 ## Docs
 
-- [docs/architecture.md](docs/architecture.md) — internals, WAL mode, schema, migration
-- [docs/configuration.md](docs/configuration.md) — full configuration reference
-- [docs/operations.md](docs/operations.md) — file locations, backup, encryption, authoring a plugin
+- [docs/architecture.md](docs/architecture.md): internals, WAL mode, schema, migration
+- [docs/configuration.md](docs/configuration.md): full configuration reference
+- [docs/operations.md](docs/operations.md): file locations, backup, encryption, authoring a plugin

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -60,9 +60,9 @@ deserialised with `json.loads` on read.
 
 ## Schema migration
 
-`SQLiteDB` tracks its on-disk schema version in `PRAGMA user_version` — a
-signed integer slot built into every SQLite file, reserved exactly for
-application-level versioning. No sibling files.
+`SQLiteDB` tracks its on-disk schema version in `PRAGMA user_version`, a
+signed integer slot built into every SQLite file and reserved for
+application-level versioning. There are no sibling files.
 
 On every `__post_init__`, `_maybe_migrate()` reads `user_version` and
 compares it to `AbstractDB.SCHEMA_VERSION` (defaults to `1` if the
@@ -76,8 +76,8 @@ versa.
 For each row:
 
 - `intent_blacklist` and `skill_blacklist` column values are folded into
-  the row's `metadata` JSON dict via `setdefault` — explicit `metadata`
-  values are never clobbered.
+  the row's `metadata` JSON dict via `setdefault`. Explicit `metadata`
+  values are never overwritten.
 - `message_blacklist` is purged outright (top-level column and any
   pre-existing `metadata["message_blacklist"]`).
 - All three legacy columns are NULLed.
@@ -91,12 +91,12 @@ The operation is idempotent: if a row has NULL legacy columns or
 with a `threading.Lock` (`_write_lock`). All `INSERT`, `UPDATE`, and
 schema mutations acquire the lock before entering the `with self.conn`
 transaction context. Reads (`SELECT`, `PRAGMA table_info`) do not acquire
-the lock — SQLite's WAL mode allows concurrent readers.
+the lock. SQLite's WAL mode allows concurrent readers.
 
 For multi-process concurrency (e.g. two `hivemind-core` processes on the
 same file), WAL mode provides safe concurrent reads and SQLite's built-in
 writer-lock serialises writes. However, `hivemind-core` does not design for
-multi-process writes to the same DB — use Redis if you need that.
+multi-process writes to the same DB. Use Redis if you need that.
 
 ## Encryption (SQLCipher)
 
@@ -104,8 +104,8 @@ When `password` is a non-empty string, `SQLiteDB` opens the file via
 `sqlcipher3` instead of the standard `sqlite3` module and issues
 `PRAGMA key='<password>'` immediately after opening the connection.
 
-The encryption is transparent to all methods — `add_item`, `search_by_value`,
-and `__iter__` work identically whether the file is encrypted or not.
+The encryption is transparent to all methods. `add_item`, `search_by_value`,
+and `__iter__` work the same whether the file is encrypted or not.
 
 An encrypted file is **not** a standard SQLite file. You cannot open it with
 the `sqlite3` CLI, DB Browser for SQLite, or any other tool without the key.
@@ -144,3 +144,6 @@ Register it under the `hivemind.database` entry-point group in
 ```
 
 `DatabaseFactory.create("my-db-plugin")` then discovers and instantiates it.
+
+---
+[Home](../README.md) · [Configuration →](configuration.md)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ With the defaults the full path resolves to:
 ~/.local/share/hivemind-core/clients.db
 ```
 
-The directory is created on first open — no manual `mkdir` needed.
+The directory is created on first open. No manual `mkdir` is needed.
 
 ### Relocating the database
 
@@ -77,7 +77,7 @@ pip install "hivemind-sqlite-database[cipher]"
 
 The password maps directly to SQLCipher's `PRAGMA key`. SQLCipher derives
 an AES-256-CBC key from the passphrase via PBKDF2. Any non-empty string is
-valid as a passphrase — SQLCipher stretches it internally.
+valid as a passphrase. SQLCipher stretches it internally.
 
 **Constraints:**
 
@@ -95,7 +95,10 @@ the same file simultaneously.
 
 ## Schema version
 
-`SQLiteDB` tracks the schema version in `PRAGMA user_version` — a built-in
-SQLite slot, no sibling files. The current target version is `2`. See
-[Architecture → Schema migration](architecture.md#schema-migration) for
+`SQLiteDB` tracks the schema version in `PRAGMA user_version`, a built-in
+SQLite slot with no sibling files. The current target version is `2`. See
+[Architecture: Schema migration](architecture.md#schema-migration) for
 what the migration does and how it runs.
+
+---
+[← Architecture](architecture.md) · [Home](../README.md) · [Operations →](operations.md)

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -26,8 +26,8 @@ sqlite3 ~/.local/share/hivemind-core/clients.db \
   ".backup /backup/clients.db.$(date +%F)"
 ```
 
-This works even with a live `hivemind-core` process — the WAL-mode backup
-is internally consistent regardless of concurrent reads or writes.
+This works even with a live `hivemind-core` process. The WAL-mode backup
+stays internally consistent regardless of concurrent reads or writes.
 
 For a quick file copy, stop the HiveMind process first and then copy all
 three files:
@@ -129,4 +129,7 @@ Register it under `hivemind.database` in `pyproject.toml`:
 "my-db-plugin" = "my_package:MyDB"
 ```
 
-`hivemind-core` will discover it automatically once installed.
+`hivemind-core` discovers it automatically once installed.
+
+---
+[← Configuration](configuration.md) · [Home](../README.md)


### PR DESCRIPTION
Rewrites README.md and docs/*.md for clarity in Simplified Technical English, tightens wording, and removes em dashes. Adds a footer navigation line to each docs page (architecture, configuration, operations) linking back to the README index.

Rewritten by Claude Sonnet 5 using the ste-writing skill (authored and reviewed by Claude Fable 5); linted with ste_lint.py.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved wording, punctuation, and formatting across the README and architecture, configuration, and operations guides.
  * Clarified schema migration, thread-safety, SQLCipher, backup, and plugin-discovery documentation.
  * Added navigation links and page footers to make related documentation easier to access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->